### PR TITLE
Add Vultr disk artifacts to stream metadata

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,14 @@ func releaseToStream(releaseArch *ReleaseArch, release Release) StreamArch {
 		artifacts.Exoscale = &exoscale
 	}
 
+	if releaseArch.Media.Vultr != nil {
+		vultr := StreamMediaDetails{
+			Release: release.Release,
+			Formats: releaseArch.Media.Vultr.Artifacts,
+		}
+		artifacts.Vultr = &vultr
+	}
+
 	if releaseArch.Media.Gcp != nil {
 		gcp := StreamMediaDetails{
 			Release: release.Release,

--- a/release.go
+++ b/release.go
@@ -27,6 +27,7 @@ type ReleaseMedia struct {
 	Qemu         *ReleaseTargetPlatform `json:"qemu"`
 	Virtualbox   *ReleaseTargetPlatform `json:"virtualbox"`
 	Vmware       *ReleaseTargetPlatform `json:"vmware"`
+	Vultr        *ReleaseTargetPlatform `json:"vultr"`
 }
 
 // ReleaseAws contains AWS image information

--- a/stream.go
+++ b/stream.go
@@ -28,6 +28,7 @@ type StreamArtifacts struct {
 	Qemu         *StreamMediaDetails `json:"qemu,omitempty"`
 	Virtualbox   *StreamMediaDetails `json:"virtualbox,omitempty"`
 	Vmware       *StreamMediaDetails `json:"vmware,omitempty"`
+	Vultr        *StreamMediaDetails `json:"vultr,omitempty"`
 }
 
 // StreamMediaDetails contains image artifact and release detail


### PR DESCRIPTION
* FCOS Jenkins pipeline builds Vultr disk images, but they
need to be mentioned in stream metadata too
* https://github.com/coreos/fedora-coreos-tracker/issues/355