### PR TITLE
gcp-cloud-launchable: convert metadata for gcp cloud launchable

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,8 +87,11 @@ func releaseToStream(releaseArch *ReleaseArch, release Release) StreamArch {
 		artifacts.Gcp = &gcp
 
 		if releaseArch.Media.Gcp != nil && releaseArch.Media.Gcp.Image != nil {
-			gcpImage := StreamCloudImage{}
-			gcpImage.Image = fmt.Sprintf("projects/fedora-coreos-cloud/global/images/family/fedora-coreos-%s", release.Stream)
+			gcpImage := StreamGcpImage{
+				Name:    releaseArch.Media.Gcp.Image.Name,
+				Family:  releaseArch.Media.Gcp.Image.Family,
+				Project: releaseArch.Media.Gcp.Image.Project,
+			}
 			cloudImages.Gcp = &gcpImage
 
 		}

--- a/release.go
+++ b/release.go
@@ -56,7 +56,14 @@ type ReleaseAzureImages struct {
 // ReleaseGcp GCP image detail
 type ReleaseGcp struct {
 	Artifacts map[string]*ImageFormat `json:"artifacts"`
-	Image     *string                 `json:"image"`
+	Image     *ReleaseCloudImageGcp   `json:"image"`
+}
+
+// ReleaseCloudImageGcp GCP cloud image information
+type ReleaseCloudImageGcp struct {
+	Project string `json:"project,omitempty"`
+	Family  string `json:"family,omitempty"`
+	Name    string `json:"name,omitempty"`
 }
 
 // ReleaseCloudImage cloud image information

--- a/stream.go
+++ b/stream.go
@@ -41,7 +41,7 @@ type StreamMediaDetails struct {
 type StreamImages struct {
 	Aws          *StreamAwsImage   `json:"aws,omitempty"`
 	Azure        *StreamCloudImage `json:"azure,omitempty"`
-	Gcp          *StreamCloudImage `json:"gcp,omitempty"`
+	Gcp          *StreamGcpImage   `json:"gcp,omitempty"`
 	Digitalocean *StreamCloudImage `json:"digitalocean,omitempty"`
 	Packet       *StreamCloudImage `json:"packet,omitempty"`
 }
@@ -60,6 +60,13 @@ type StreamAwsImage struct {
 type StreamAwsAMI struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
+}
+
+// StreamGcpImage GCP cloud image information
+type StreamGcpImage struct {
+	Project string `json:"project,omitempty"`
+	Family  string `json:"family,omitempty"`
+	Name    string `json:"name,omitempty"`
 }
 
 // StreamUpdates contains release version


### PR DESCRIPTION
This change works with https://github.com/coreos/fedora-coreos-releng-automation/pull/112 and adds the name, family and project metadata for GCP cloud launchable image from release.json to $stream.json.

Signed-off-by: Allen Bai <abai@redhat.com>