### PR TITLE
Add ImageFormat rootfs field for PXE

### DIFF
--- a/common.go
+++ b/common.go
@@ -10,6 +10,7 @@ type ImageFormat struct {
 	Disk      *ImageType `json:"disk,omitempty"`
 	Kernel    *ImageType `json:"kernel,omitempty"`
 	Initramfs *ImageType `json:"initramfs,omitempty"`
+	Rootfs    *ImageType `json:"rootfs,omitempty"`
 }
 
 // ImageType contains image detail


### PR DESCRIPTION
For https://github.com/coreos/fedora-coreos-tracker/issues/390.  Example output:

```json
{
    "stream": "testing-devel",
    "metadata": {
        "last-modified": "2020-07-20T00:19:26Z"
    },
    "architectures": {
        "x86_64": {
            "artifacts": {
                "metal": {
                    "release": "32.20200719.dev.0",
                    "formats": {
                        "4k.raw": {
                            "disk": {
                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal4k.x86_64.raw",
                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal4k.x86_64.raw.sig",
                                "sha256": "a21ab5471c0402f15b587710dd3f2326a75f06ff38e2ed471951e60b9ba59501"
                            }
                        },
                        "iso": {
                            "disk": {
                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live.x86_64.iso",
                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live.x86_64.iso.sig",
                                "sha256": "c2406a250c4500cf3199d33c1ef473d16731f36fa96773538c263a0e3b3c721d"
                            }
                        },
                        "pxe": {
                            "kernel": {
                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-kernel-x86_64",
                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-kernel-x86_64.sig",
                                "sha256": "ca79086041c6a4471129cb48b30c72dc7854c912c20bf1db1785c5a88eca06ec"
                            },
                            "initramfs": {
                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-initramfs.x86_64.img",
                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-initramfs.x86_64.img.sig",
                                "sha256": "71d9fdce247e8e873b4dd580c42344f286e92b318276f5aba322b53e8feabdff"
                            },
                            "rootfs": {
                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-rootfs.x86_64.img",
                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-live-rootfs.x86_64.img.sig",
                                "sha256": "934d2c72e95b275a88b36a20a453464ba03c4fd858c106b692e896a00e977277"
                            }
                        },
                        "raw": {
                            "disk": {
                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal.x86_64.raw",
                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-metal.x86_64.raw.sig",
                                "sha256": "d4a7e2f48a6a2437d8ed5d2f9e7d5a269cd894081169b7e2757f885c5f2ce377"
                            }
                        }
                    }
                },
                "qemu": {
                    "release": "32.20200719.dev.0",
                    "formats": {
                        "qcow2": {
                            "disk": {
                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-qemu.x86_64.qcow2",
                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/32.20200719.dev.0/x86_64/fedora-coreos-32.20200719.dev.0-qemu.x86_64.qcow2.sig",
                                "sha256": "d2e907ed25da78e487c319ec748d334a032862e806cb4d70eaee2537ba3b6487"
                            }
                        }
                    }
                }
            }
        }
    }
}
```

See https://github.com/coreos/coreos-assembler/pull/1608, but can be merged independently of that PR.