### PR TITLE
Drop EOL Go versions, bump linter, restrict workflow access to repo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.33
+        version: v1.41.1
         args: -E=gofmt --timeout=30m0s

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     name: test build
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.15.x, 1.16.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test-build:
     name: test build

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/coreos/fedora-coreos-stream-generator
 
-go 1.12
+go 1.15
 
 require github.com/coreos/stream-metadata-go v0.0.0-20210225230131-70edb9eb47b3


### PR DESCRIPTION
F33, F34, and OCP 4.9 have Go 1.15 or higher.