### PR TITLE
dependabot: check for updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily


### PR DESCRIPTION
The only module in `go.mod` is the one we care about
(`stream-metadata-go`), so just shift to daily.