### PR TITLE
Add `-version` option, and `metadata.generator` field in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+VERSION=$(shell git describe --dirty --always)
+
 .PHONY: all
 all: fedora-coreos-stream-generator
 
 fedora-coreos-stream-generator: main.go go.mod Makefile
-	go build .
+	go build -ldflags "$(GLDFLAGS) -X main.Version=$(VERSION)" .
 
 .PHONY: test
 test:

--- a/main.go
+++ b/main.go
@@ -149,8 +149,11 @@ func run() error {
 	}
 
 	streamMetadata := stream.Stream{
-		Stream:        rel.Stream,
-		Metadata:      stream.Metadata{LastModified: time.Now().UTC().Format(time.RFC3339)},
+		Stream: rel.Stream,
+		Metadata: stream.Metadata{
+			LastModified: time.Now().UTC().Format(time.RFC3339),
+			Generator:    generator,
+		},
 		Architectures: rel.ToStreamArchitectures(),
 	}
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,10 @@ import (
 	"github.com/coreos/stream-metadata-go/stream"
 )
 
+// Substituted by Makefile
+var Version = "was not built properly"
+
+var generator = "fedora-coreos-stream-generator " + Version
 var errReleaseIndexMissing = errors.New("Please specify release index url or release override")
 
 // getReleaseURL gets path for latest release.json available
@@ -89,8 +93,15 @@ func run() error {
 	flag.StringVar(&outputFile, "output-file", "", "Save output into a file")
 	var prettyPrint bool
 	flag.BoolVar(&prettyPrint, "pretty-print", false, "Pretty-print output")
+	var version bool
+	flag.BoolVar(&version, "version", false, "Show version")
 
 	flag.Parse()
+
+	if version {
+		fmt.Println(generator)
+		return nil
+	}
 
 	var releasePath string
 	if releasesURL == "" && overrideReleasePath == "" {

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 outf=$(mktemp --suffix=fcos-stream)
 expected=fixtures/stream.json
 ./fedora-coreos-stream-generator -pretty-print -releases ./fixtures/releases.json -output-file "${outf}".tmp
-# The last-modified changes based on time
+# The last-modified and generator change based on time and branch state
 jq "del(.metadata)" < "${outf}".tmp > "${outf}" && rm -f "${outf}".tmp
 if ! diff -u "${expected}" "${outf}"; then
     echo "error: Failed to match expected ${expected}" 1>&2


### PR DESCRIPTION
Record the Git commit of the generator in the output for debugging, and so code review can verify that a current generator was used.

Fixes https://github.com/coreos/fedora-coreos-stream-generator/issues/29.