### PR TITLE
Bump minimum Go version to 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: test build
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.17.x, 1.18.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/coreos/fedora-coreos-stream-generator
 
-go 1.15
+go 1.17
 
 require github.com/coreos/stream-metadata-go v0.3.0


### PR DESCRIPTION
Go 1.15 and 1.16 are EOL.